### PR TITLE
Increase royalty cap to 90%

### DIFF
--- a/exchange-v2/contracts/RaribleTransferManager.sol
+++ b/exchange-v2/contracts/RaribleTransferManager.sol
@@ -134,7 +134,7 @@ abstract contract RaribleTransferManager is OwnableUpgradeable, ITransferManager
         LibPart.Part[] memory fees = getRoyaltiesByAssetType(matchNft);
 
         (uint result, uint totalRoyalties) = transferFees(matchCalculate, rest, amount, fees, from, transferDirection, ROYALTY);
-        require(totalRoyalties <= 5000, "Royalties are too high (>50%)");
+        require(totalRoyalties <= 9000, "Royalties are too high (>90%)");
         return result;
     }
 


### PR DESCRIPTION
This is a simple PR that increases the limit in `transferRoyalties` from 50% to 90%.

Why:
- MintGate.io is working with creators and charities that need higher royalities for good cause fundraising

Questions:
- Are there other places in the code that need to updated to increase the royalties
- Why was the 50% limit placed in the first place?

Before merging:
- Needs at lease one test for testing royalties as high as 90% (I need some help here)