### PR TITLE
Fix - fillRight function bug

### DIFF
--- a/exchange-v2/contracts/LibFill.sol
+++ b/exchange-v2/contracts/LibFill.sol
@@ -37,7 +37,7 @@ library LibFill {
     function fillRight(uint leftMakeValue, uint leftTakeValue, uint rightMakeValue, uint rightTakeValue) internal pure returns (FillResult memory result) {
         uint makerValue = LibMath.safeGetPartialAmountFloor(rightTakeValue, leftMakeValue, leftTakeValue);
         require(makerValue <= rightMakeValue, "fillRight: unable to fill");
-        return FillResult(rightTakeValue, makerValue);
+        return FillResult(rightTakeValue, rightMakeValue);
     }
 
     function fillLeft(uint leftMakeValue, uint leftTakeValue, uint rightMakeValue, uint rightTakeValue) internal pure returns (FillResult memory result) {


### PR DESCRIPTION
_**1. Orders**_
Order1 {
  maker: 'User#1',
  makeAsset: {
    assetType: {
      assetClass: '0x8ae85d84',
      data: '0x00000000000000000000000040a42baf86fc821f972ad2ac878729063ceef403'
    },
    value: 100
  },
  taker: '0x0000000000000000000000000000000000000000',
  takeAsset: {
    assetType: {
      assetClass: '0x8ae85d84',
      data: '0x00000000000000000000000096f3ce39ad2bfdcf92c0f6e2c2cabf83874660fc'
    },
    value: 90
  },
  salt: 1,
  start: 0,
  end: 0,
  dataType: '0xffffffff',
  data: '0x'
}

Order2 {
  maker: ‘User#2’,
  makeAsset: {
    assetType: {
      assetClass: '0x8ae85d84',
      data: '0x00000000000000000000000096f3ce39ad2bfdcf92c0f6e2c2cabf83874660fc'
    },
    value: 100
  },
  taker: '0x0000000000000000000000000000000000000000',
  takeAsset: {
    assetType: {
      assetClass: '0x8ae85d84',
      data: '0x00000000000000000000000040a42baf86fc821f972ad2ac878729063ceef403'
    },
    value: 110
  },
  salt: 1,
  start: 0,
  end: 0,
  dataType: '0xffffffff',
  data: '0x'
}

**_2. Match Orders_**

matchOrders(user2Order, user2Signature, user1Order, user1Signature)

**_3. Results_**

Expected Result:
 User#1 t1 Balance 0
 User#1 t2 Balance 90
 User#2 t1 Balance 100
 User#2 t2 Balance 10

Result:
 User#1 t1 Balance 1
 User#1 t2 Balance 90
 User#2 t1 Balance 99
 User#2 t2 Balance 10
=> An unfair trade has occurred