### PR TITLE
Pt 602 wrong approvals collections

### DIFF
--- a/tokens/contracts/create-2/ERC1155RaribleFactoryC2.sol
+++ b/tokens/contracts/create-2/ERC1155RaribleFactoryC2.sol
@@ -28,15 +28,15 @@ contract ERC1155RaribleFactoryC2 is Ownable{
     }
 
     function createToken(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, uint salt) external {        
-        address beaconProxy = deployProxy(getData(_name, _symbol, baseURI, contractURI), salt);
+        address beaconProxy = deployProxy(getDataPublic(_name, _symbol, baseURI, contractURI), salt);
 
         ERC1155Rarible token = ERC1155Rarible(beaconProxy);
         token.transferOwnership(_msgSender());
         emit Create1155RaribleProxy(beaconProxy);
     }
     
-    function createToken(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address[] memory operators, uint salt) external {
-        address beaconProxy = deployProxy(getData(_name, _symbol, baseURI, contractURI, operators), salt);
+    function createToken(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address[] memory, uint salt) external {
+        address beaconProxy = deployProxy(getDataPrivate(_name, _symbol, baseURI, contractURI), salt);
 
         ERC1155Rarible token = ERC1155Rarible(address(beaconProxy));
         token.transferOwnership(_msgSender());
@@ -65,7 +65,7 @@ contract ERC1155RaribleFactoryC2 is Ownable{
         view
         returns (address)
     {   
-        bytes memory bytecode = getCreationBytecode(getData(_name, _symbol, baseURI, contractURI));
+        bytes memory bytecode = getCreationBytecode(getDataPublic(_name, _symbol, baseURI, contractURI));
 
         bytes32 hash = keccak256(
             abi.encodePacked(bytes1(0xff), address(this), _salt, keccak256(bytecode))
@@ -74,17 +74,13 @@ contract ERC1155RaribleFactoryC2 is Ownable{
         return address(uint160(uint(hash)));
     }
 
-    function getData(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI) view internal returns(bytes memory){
-        return abi.encodeWithSelector(ERC1155Rarible(0).__ERC1155Rarible_init.selector, _name, _symbol, baseURI, contractURI, transferProxy, lazyTransferProxy);
-    }
-
     //returns address that contract with such arguments will be deployed on
-    function getAddress(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address[] memory operators, uint _salt)
+    function getAddress(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address[] memory, uint _salt)
         public
         view
         returns (address)
     {   
-        bytes memory bytecode = getCreationBytecode(getData(_name, _symbol, baseURI, contractURI, operators));
+        bytes memory bytecode = getCreationBytecode(getDataPrivate(_name, _symbol, baseURI, contractURI));
 
         bytes32 hash = keccak256(
             abi.encodePacked(bytes1(0xff), address(this), _salt, keccak256(bytecode))
@@ -93,8 +89,12 @@ contract ERC1155RaribleFactoryC2 is Ownable{
         return address(uint160(uint(hash)));
     }
 
-    function getData(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address[] memory operators) view internal returns(bytes memory){
-        return abi.encodeWithSelector(ERC1155Rarible(0).__ERC1155RaribleUser_init.selector, _name, _symbol, baseURI, contractURI, operators, transferProxy, lazyTransferProxy);
+    function getDataPublic(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI) view internal returns(bytes memory){
+        return abi.encodeWithSelector(ERC1155Rarible(0).__ERC1155Rarible_init.selector, _name, _symbol, baseURI, contractURI, transferProxy, lazyTransferProxy);
+    }
+
+    function getDataPrivate(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI) view internal returns(bytes memory){
+        return abi.encodeWithSelector(ERC1155Rarible(0).__ERC1155RaribleUser_init.selector, _name, _symbol, baseURI, contractURI, transferProxy, lazyTransferProxy);
     }
 
 }

--- a/tokens/contracts/erc-1155/ERC1155Rarible.sol
+++ b/tokens/contracts/erc-1155/ERC1155Rarible.sol
@@ -11,11 +11,8 @@ contract ERC1155Rarible is ERC1155Base, IsPrivateCollection, MinterAccessControl
     event CreateERC1155Rarible(address owner, string name, string symbol);
     event CreateERC1155RaribleUser(address owner, string name, string symbol);
 
-    function __ERC1155RaribleUser_init(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address[] memory operators, address transferProxy, address lazyTransferProxy) external virtual {
+    function __ERC1155RaribleUser_init(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address transferProxy, address lazyTransferProxy) external virtual {
         __ERC1155Rarible_init_unchained(_name, _symbol, baseURI, contractURI, transferProxy, lazyTransferProxy);
-        for(uint i = 0; i < operators.length; i++) {
-            setApprovalForAll(operators[i], true);
-        }
 
         isPrivate = true;
         emit CreateERC1155RaribleUser(_msgSender(), _name, _symbol);

--- a/tokens/contracts/erc-1155/erc-1155-meta/ERC1155RaribleMeta.sol
+++ b/tokens/contracts/erc-1155/erc-1155-meta/ERC1155RaribleMeta.sol
@@ -12,16 +12,12 @@ contract ERC1155RaribleMeta is ERC1155Base, IsPrivateCollection, MinterAccessCon
     event CreateERC1155Rarible(address owner, string name, string symbol);
     event CreateERC1155RaribleUser(address owner, string name, string symbol);
 
-    function __ERC1155RaribleUser_init(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address[] memory operators, address transferProxy, address lazyTransferProxy) external {
+    function __ERC1155RaribleUser_init(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address transferProxy, address lazyTransferProxy) external {
         __ERC1155Rarible_init_unchained(_name, _symbol, baseURI, contractURI, transferProxy, lazyTransferProxy);
 
-        for(uint i = 0; i < operators.length; i++) {
-            setApprovalForAll(operators[i], true);
-        }
         __MetaTransaction_init_unchained("ERC1155RaribleUserMeta", "1");
         
         isPrivate = true;
-
         emit CreateERC1155RaribleUser(_msgSender(), _name, _symbol);
     }
     
@@ -31,7 +27,6 @@ contract ERC1155RaribleMeta is ERC1155Base, IsPrivateCollection, MinterAccessCon
         __MetaTransaction_init_unchained("ERC1155RaribleMeta", "1");
 
         isPrivate = false;
-
         emit CreateERC1155Rarible(_msgSender(), _name, _symbol);
     }
 

--- a/tokens/contracts/erc-721-minimal/erc-721-minimal-meta/ERC721RaribleMeta.sol
+++ b/tokens/contracts/erc-721-minimal/erc-721-minimal-meta/ERC721RaribleMeta.sol
@@ -12,17 +12,12 @@ contract ERC721RaribleMeta is ERC721BaseMinimal, IsPrivateCollection, MinterAcce
     event CreateERC721Rarible(address owner, string name, string symbol);
     event CreateERC721RaribleUser(address owner, string name, string symbol);
 
-    function __ERC721RaribleUser_init(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address[] memory operators, address transferProxy, address lazyTransferProxy) external {
+    function __ERC721RaribleUser_init(string memory _name, string memory _symbol, string memory baseURI, string memory contractURI, address transferProxy, address lazyTransferProxy) external {
         __ERC721Rarible_init_unchained(_name, _symbol, baseURI, contractURI, transferProxy, lazyTransferProxy);
-
-        for(uint i = 0; i < operators.length; i++) {
-            setApprovalForAll(operators[i], true);
-        }
 
         __MetaTransaction_init_unchained("ERC721RaribleUserMeta", "1");
 
         isPrivate = true;
-
         emit CreateERC721RaribleUser(_msgSender(), _name, _symbol);
     }
 
@@ -32,7 +27,6 @@ contract ERC721RaribleMeta is ERC721BaseMinimal, IsPrivateCollection, MinterAcce
         __MetaTransaction_init_unchained("ERC721RaribleMeta", "1");
 
         isPrivate = false;
-
         emit CreateERC721Rarible(_msgSender(), _name, _symbol);
     }
 

--- a/tokens/test-default-approval-721.sh
+++ b/tokens/test-default-approval-721.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-truffle test ./test/erc-721/DefaultApproval.test.js ./test/contracts/erc-721/ERC721DefaultApprovalTest.sol
+truffle test ./test/erc-721-minimal/DefaultApproval.test.js \
+            ./test/contracts/erc-721/ERC721DefaultApprovalTest.sol

--- a/tokens/test-mint-721.sh
+++ b/tokens/test-mint-721.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-truffle test ./test/erc-721/Mint721Validator.test.js ./test/contracts/erc-721/Mint721ValidatorTest.sol ./test/contracts/TestERC1271.sol
+truffle test ./test/erc-721-minimal/Mint721Validator.test.js \
+            ./test/contracts/erc-721/Mint721ValidatorTest.sol \
+            ./test/contracts/TestERC1271.sol

--- a/tokens/test/MetaTx.test.js
+++ b/tokens/test/MetaTx.test.js
@@ -97,14 +97,14 @@ contract("MetaTxTokenTest", accounts => {
     erc721NoMetaTx = await deployProxy(ERC721NoMetaTx, ["Rarible", "RARI", "ipfs:/", "", ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC721Rarible_init' });
     erc721WithMetaTx = await deployProxy(ERC721MetaTx, ["Rarible", "RARI", "ipfs:/", "", ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC721Rarible_init' });
 
-    erc721UserNoMetaTx = await deployProxy(ERC721NoMetaTx, ["Rarible", "RARI", "ipfs:/", "", [], ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC721RaribleUser_init' });
-    erc721UserWithMetaTx = await deployProxy(ERC721MetaTx, ["Rarible", "RARI", "ipfs:/", "", [], ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC721RaribleUser_init' });
+    erc721UserNoMetaTx = await deployProxy(ERC721NoMetaTx, ["Rarible", "RARI", "ipfs:/", "", ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC721RaribleUser_init' });
+    erc721UserWithMetaTx = await deployProxy(ERC721MetaTx, ["Rarible", "RARI", "ipfs:/", "", ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC721RaribleUser_init' });
 
     erc1155NoMetaTx = await deployProxy(ERC1155NoMetaTx, ["Rarible", "RARI", "ipfs:/", "", ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC1155Rarible_init' });
     erc1155WithMetaTx = await deployProxy(ERC1155MetaTx, ["Rarible", "RARI", "ipfs:/", "", ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC1155Rarible_init' });
 
-    erc1155UserNoMetaTx = await deployProxy(ERC1155NoMetaTx, ["Rarible", "RARI", "ipfs:/", "", [], ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC1155RaribleUser_init' });
-    erc1155UserWithMetaTx = await deployProxy(ERC1155MetaTx, ["Rarible", "RARI", "ipfs:/", "", [], ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC1155RaribleUser_init' });
+    erc1155UserNoMetaTx = await deployProxy(ERC1155NoMetaTx, ["Rarible", "RARI", "ipfs:/", "", ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC1155RaribleUser_init' });
+    erc1155UserWithMetaTx = await deployProxy(ERC1155MetaTx, ["Rarible", "RARI", "ipfs:/", "", ZERO_ADDRESS, ZERO_ADDRESS], { initializer: '__ERC1155RaribleUser_init' });
 
     domainData721Rarible = {
           name: "ERC721RaribleMeta",

--- a/tokens/test/erc-1155/ERC1155RaribleUser.test.js
+++ b/tokens/test/erc-1155/ERC1155RaribleUser.test.js
@@ -27,7 +27,7 @@ contract("ERC1155RaribleUser", accounts => {
 
   beforeEach(async () => {
     token = await Testing.new();
-    await token.__ERC1155RaribleUser_init(name, "TST", "ipfs:/", "ipfs:/", [whiteListProxy], accounts[6], accounts[7], {from: tokenOwner});
+    await token.__ERC1155RaribleUser_init(name, "TST", "ipfs:/", "ipfs:/", accounts[6], accounts[7], {from: tokenOwner});
   });
 
   it("approve for all", async () => {
@@ -122,6 +122,12 @@ contract("ERC1155RaribleUser", accounts => {
     const tokenURI = "//uri";
     const signature = await getSignature(tokenId, tokenURI, supply, creators([minter]), fees([royaltiesBeneficiary1,royaltiesBeneficiary2,royaltiesBeneficiary3]), minter);
 
+    //throw while mintAndTransfer, because tokenOwner don`t set approve in __ERC1155RaribleUser_init
+    await expectThrow(
+      token.mintAndTransfer([tokenId, tokenURI, supply, creators([minter]), fees([royaltiesBeneficiary1,royaltiesBeneficiary2,royaltiesBeneficiary3]), [signature]], transferTo, mint, {from: whiteListProxy})
+    );
+
+    await token.setApprovalForAll(whiteListProxy, true, {from: tokenOwner});
     const tx = await token.mintAndTransfer([tokenId, tokenURI, supply, creators([minter]), fees([royaltiesBeneficiary1,royaltiesBeneficiary2,royaltiesBeneficiary3]), [signature]], transferTo, mint, {from: whiteListProxy});
     const addressValue = await token.royaltyInfo(tokenId, WEIGHT_PRICE);
 
@@ -165,6 +171,12 @@ contract("ERC1155RaribleUser", accounts => {
 
     const signature = await getSignature(tokenId, tokenURI, supply, creators([minter]), [], minter);
 
+    //throw while mintAndTransfer, because tokenOwner don`t set approve in __ERC1155RaribleUser_init
+    await expectThrow(
+      token.mintAndTransfer([tokenId, tokenURI, supply, creators([minter]), [], [signature]], transferTo, mint, {from: whiteListProxy})
+    );
+
+    await token.setApprovalForAll(whiteListProxy, true, {from: tokenOwner});
     await token.mintAndTransfer([tokenId, tokenURI, supply, creators([minter]), [], [signature]], transferTo, mint, {from: whiteListProxy});
 
 		assert.equal(await token.uri(tokenId), "ipfs:/" + tokenURI);

--- a/tokens/test/erc-721-minimal/RaribleUser.test.js
+++ b/tokens/test/erc-721-minimal/RaribleUser.test.js
@@ -21,7 +21,7 @@ contract("ERC721RaribleUser minimal", accounts => {
 
   beforeEach(async () => {
     token = await Testing.new();
-    await token.__ERC721RaribleUser_init(name, "RARI", "https://ipfs.rarible.com", "https://ipfs.rarible.com", [whiteListProxy], zeroAddress, zeroAddress, { from: tokenOwner });
+    await token.__ERC721RaribleUser_init(name, "RARI", "https://ipfs.rarible.com", "https://ipfs.rarible.com", zeroAddress, zeroAddress, { from: tokenOwner });
   });
 
   it("check for ERC165 interface", async () => {
@@ -78,6 +78,12 @@ contract("ERC721RaribleUser minimal", accounts => {
     const tokenURI = "//uri";
     const signature = await getSignature(tokenId, tokenURI, creators([minter]), fees([royaltiesBeneficiary1,royaltiesBeneficiary2,royaltiesBeneficiary3]), minter);
 
+    //throw while mintAndTransfer, because tokenOwner don`t set approve in __ERC721RaribleUser_init
+    await expectThrow (
+      token.mintAndTransfer([tokenId, tokenURI, creators([minter]), fees([royaltiesBeneficiary1,royaltiesBeneficiary2,royaltiesBeneficiary3]), [signature]], transferTo, {from: whiteListProxy})
+    );
+
+    await token.setApprovalForAll(whiteListProxy, true, {from: tokenOwner});
     const tx = await token.mintAndTransfer([tokenId, tokenURI, creators([minter]), fees([royaltiesBeneficiary1,royaltiesBeneficiary2,royaltiesBeneficiary3]), [signature]], transferTo, {from: whiteListProxy});
     const addressValue = await token.royaltyInfo(tokenId, WEIGHT_PRICE);
 
@@ -100,6 +106,12 @@ contract("ERC721RaribleUser minimal", accounts => {
 
     const signature = await getSignature(tokenId, tokenURI, creators([minter]), fees, minter);
 
+    //throw while mintAndTransfer, because tokenOwner don`t set approve in __ERC721RaribleUser_init
+    await expectThrow(
+      token.mintAndTransfer([tokenId, tokenURI, creators([minter]), fees, [signature]], transferTo, {from: whiteListProxy})
+    );
+
+    await token.setApprovalForAll(whiteListProxy, true, {from: tokenOwner});
     await token.mintAndTransfer([tokenId, tokenURI, creators([minter]), fees, [signature]], transferTo, {from: whiteListProxy});
 
     assert.equal(await token.ownerOf(tokenId), transferTo);
@@ -134,6 +146,7 @@ contract("ERC721RaribleUser minimal", accounts => {
     const signature1 = await getSignature(tokenId, tokenURI, creators([minter, creator2]), fees, minter);
     const signature2 = await getSignature(tokenId, tokenURI, creators([minter, creator2]), fees, creator2);
 
+    await token.setApprovalForAll(whiteListProxy, true, {from: tokenOwner});
     await token.mintAndTransfer([tokenId, tokenURI, creators([minter, creator2]), fees, [signature1, signature2]], transferTo, {from: whiteListProxy});
 
     assert.equal(await token.ownerOf(tokenId), transferTo);


### PR DESCRIPTION
Summary:
Delete approvals for operators in initialization functions of private tokens
It means tokenOwner should take all approvals by call method setApproveForAll
Repair all tests, 168 passing